### PR TITLE
environment variables 

### DIFF
--- a/formsfeeder.pf4j-spring/src/main/java/com/_4point/aem/formsfeeder/pf4j/spring/EnvironmentConsumer.java
+++ b/formsfeeder.pf4j-spring/src/main/java/com/_4point/aem/formsfeeder/pf4j/spring/EnvironmentConsumer.java
@@ -11,6 +11,9 @@ public interface EnvironmentConsumer {
 	public static final String FORMSFEEDER_PLUGINS_ENV_PARAM_PREFIX = "formsfeeder.plugins.";
 	public static final String AEM_HOST_ENV_PARAM = FORMSFEEDER_PLUGINS_ENV_PARAM_PREFIX + "aemHost";
 	public static final String AEM_PORT_ENV_PARAM = FORMSFEEDER_PLUGINS_ENV_PARAM_PREFIX + "aemPort";
+	public static final String AEM_USE_SSL_PARAM = FORMSFEEDER_PLUGINS_ENV_PARAM_PREFIX + "aemUseSsl";
+	public static final String AEM_USERNAME_PARAM = FORMSFEEDER_PLUGINS_ENV_PARAM_PREFIX + "aemUsername";
+	public static final String AEM_SECRET_PARAM = FORMSFEEDER_PLUGINS_ENV_PARAM_PREFIX + "aemSecret";
 	
 	public void accept(Environment environment);
 }


### PR DESCRIPTION
Adding additional properties needed when changing aemHost and Port combinations. For example, on prem utilizing http and different credentials than say non prod cloud using https and again different credentials. These allow for all plugins to use the same properties so we can change aem instance across all plugins if necessary (i.e. switching dev environment between on prem for testing and non prod cloud, as well as maintaining the different credentials between non prod and prod cloud instances).