### PR TITLE
12 data source list deconstructor enhancement

### DIFF
--- a/formsfeeder.core/src/main/java/com/_4point/aem/formsfeeder/core/datasource/DataSourceList.java
+++ b/formsfeeder.core/src/main/java/com/_4point/aem/formsfeeder/core/datasource/DataSourceList.java
@@ -3,10 +3,12 @@ package com._4point.aem.formsfeeder.core.datasource;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -15,6 +17,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Spliterator;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -30,6 +33,9 @@ import com._4point.aem.formsfeeder.core.support.Jdk8Utils;
 
 /**
  * Wraps a list of DataSource objects and provides common functions for operating on that list.
+ * 
+ * In most cases, client code will not directly interact with a DataSourceList (other than to determine whether it's empty)
+ * but, instead, will get a builder (to create a DataSourceList) or a Deconstructor (to extract data from a DataSourceList). 
  *
  */
 public class DataSourceList implements Iterable<DataSource> {
@@ -326,7 +332,17 @@ public class DataSourceList implements Iterable<DataSource> {
 		public DataSourceList build() {
 			return DataSourceList.from(underConstruction);
 		}
-		
+
+		/**
+		 * Convert contents of a DataSource to a String.  Assumes that the source input stream is UTF-8.
+		 * 
+		 * @param ds
+		 * @return contents of the DataSource as a String object.
+		 */
+		public static final <T> DataSource objToStringDS(String name, T object) {
+			return new StringDataSource(Objects.toString(object), Objects.requireNonNull(name, "Name cannot be null.")); 
+		}
+
 		public Builder add(DataSource ds) {
 			underConstruction.add(Objects.requireNonNull(ds, "DataSource cannot be null."));
 			return this;
@@ -645,10 +661,6 @@ public class DataSourceList implements Iterable<DataSource> {
 		 * @return contents of the DataSource as a String object.
 		 */
 		public static final String dsToString(DataSource ds) {
-			if (ds instanceof StringDataSource) {
-				// Shortcut if this is already a StringDataSource
-				return ((StringDataSource) ds).contents();
-			}
 			return dsToString(ds, StandardCharsets.UTF_8);	// Assume UTF-8
 		}
 		
@@ -722,6 +734,54 @@ public class DataSourceList implements Iterable<DataSource> {
 		public final List<byte[]> getByteArrays(Predicate<DataSource> predicate) {
 			return dsList.getDataSources(predicate).stream()
 					.map(Deconstructor::dsToByteArray)
+					.collect(Collectors.toList());
+		}
+
+		public static final Content dsToContent (DataSource ds) {
+			return new Content(dsToByteArray(ds), ds.contentType());
+		}
+		
+		public final Optional<Content> getContentByName(String name) {
+			return dsList.getDataSourceByName(name).map(Deconstructor::dsToContent);
+		}
+
+		public final Optional<Content> getContent(Predicate<DataSource> predicate) {
+			return dsList.getDataSource(predicate).map(Deconstructor::dsToContent);
+		}
+
+		public final List<Content> getContentsByName(String name) {
+			return dsList.getDataSourcesByName(name).stream()
+					.map(Deconstructor::dsToContent)
+					.collect(Collectors.toList());
+		}
+
+		public final List<Content> getContents(Predicate<DataSource> predicate) {
+			return dsList.getDataSources(predicate).stream()
+					.map(Deconstructor::dsToContent)
+					.collect(Collectors.toList());
+		}
+
+		public static final FileContent dsToFileContent (DataSource ds) {
+			return new FileContent(dsToByteArray(ds), ds.contentType(), ds.filename().orElseThrow(()->new UnsupportedOperationException("DataSource does not have filename, use Content object instead.")));
+		}
+		
+		public final Optional<FileContent> getFileContentByName(String name) {
+			return dsList.getDataSourceByName(name).map(Deconstructor::dsToFileContent);
+		}
+
+		public final Optional<FileContent> getFileContent(Predicate<DataSource> predicate) {
+			return dsList.getDataSource(predicate).map(Deconstructor::dsToFileContent);
+		}
+
+		public final List<FileContent> getFileContentsByName(String name) {
+			return dsList.getDataSourcesByName(name).stream()
+					.map(Deconstructor::dsToFileContent)
+					.collect(Collectors.toList());
+		}
+
+		public final List<FileContent> getFileContents(Predicate<DataSource> predicate) {
+			return dsList.getDataSources(predicate).stream()
+					.map(Deconstructor::dsToFileContent)
 					.collect(Collectors.toList());
 		}
 
@@ -914,6 +974,266 @@ public class DataSourceList implements Iterable<DataSource> {
 			public <T> Function<DataSource, T> get(Class<T> type) {
 				return ds->type.cast(favorites.get(type).apply(ds));
 			}
+		}
+	}
+	
+	/**
+	 * Generic content, stored in memory with a mimetype
+	 *
+	 */
+	public static class Content {
+		protected final byte[] bytes;
+		protected final MimeType mimeType;
+		
+		private Content(byte[] bytes, MimeType mimeType) {
+			super();
+			this.bytes = bytes;
+			this.mimeType = mimeType;
+		}
+
+		public byte[] bytes() {
+			return bytes;
+		}
+
+		public MimeType mimeType() {
+			return mimeType;
+		}
+
+		public static Content from(byte[] ba, MimeType mimeType) {
+			return new Content(ba, mimeType);
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + Arrays.hashCode(bytes);
+			result = prime * result + ((mimeType == null) ? 0 : mimeType.hashCode());
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (obj == null)
+				return false;
+			if (getClass() != obj.getClass())
+				return false;
+			Content other = (Content) obj;
+			if (!Arrays.equals(bytes, other.bytes))
+				return false;
+			if (mimeType == null) {
+				if (other.mimeType != null)
+					return false;
+			} else if (!mimeType.equals(other.mimeType))
+				return false;
+			return true;
+		}
+		
+	}
+	
+	/**
+	 * The bytes from a file (retains the filename)
+	 *
+	 */
+	public static class FileContent extends Content {
+		private final Path path;
+
+		private FileContent(byte[] bytes, MimeType mimeType, Path path) {
+			super(bytes, mimeType);
+			this.path = path;
+		}
+		
+		public Path path() {
+			return path;
+		}
+
+		public static FileContent from(byte[] ba, MimeType mimeType, Path path) {
+			return new FileContent(Objects.requireNonNull(ba, "content cannot be null"), Objects.requireNonNull(mimeType, "MimeType cannot be null"), Objects.requireNonNull(path, "Path cannot be null"));
+		}
+		public static FileContent from(byte[] ba, Path path, MimeTypeFileTypeMap map) {
+			return from(ba, determineMimeType(path, map), path);
+		}
+		public static FileContent from(byte[] ba, Path path) {
+			return from(ba, path, UnmodifiableFileExtensionsMap.DEFAULT_MAP);
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = super.hashCode();
+			result = prime * result + ((path == null) ? 0 : path.hashCode());
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (!super.equals(obj))
+				return false;
+			if (getClass() != obj.getClass())
+				return false;
+			FileContent other = (FileContent) obj;
+			if (path == null) {
+				if (other.path != null)
+					return false;
+			} else if (!path.equals(other.path))
+				return false;
+			return true;
+		}
+	}
+	
+	private static MimeType determineMimeType(Path filePath, MimeTypeFileTypeMap map) {
+		return map.mimeType(filePath).orElse(StandardMimeTypes.APPLICATION_OCTET_STREAM_TYPE);
+	}	
+	
+	public static interface Mapper<T> {
+		public BiFunction<String, T, DataSource> to();
+		public Function<DataSource, T> from();
+		public Class<T> target();
+	}
+
+	public static class StandardMappers {
+		public static Mapper<String> STRING = new Mapper<String>() {
+			
+			@Override
+			public BiFunction<String, String, DataSource> to() { return Builder::<String>objToStringDS; }
+			
+			@Override
+			public Function<DataSource, String> from() { return Deconstructor::dsToString; }
+			
+			@Override
+			public Class<String> target() { return String.class; }
+		};
+
+		public static Mapper<String> createStringMapper(Charset cs) {
+			return new Mapper<String>() {
+
+				@Override
+				public BiFunction<String, String, DataSource> to() { return Builder::<String>objToStringDS; }
+
+				@Override
+				public Function<DataSource, String> from() { return ds->Deconstructor.dsToString(ds, cs); }
+
+				@Override
+				public Class<String> target() { return String.class; }
+			};
+		}
+		
+		public static Mapper<byte[]> BYTEARRAY = new Mapper<byte[]>() {
+
+			@Override
+			public BiFunction<String, byte[], DataSource> to() { return (name, ba)->new ByteArrayDataSource(ba, Objects.requireNonNull(name, "Name cannot be null.")); }
+
+			@Override
+			public Function<DataSource, byte[]> from() { return Deconstructor::dsToByteArray; }
+
+			@Override
+			public Class<byte[]> target() { return byte[].class; }
+		};
+		
+		public static Mapper<byte[]> createByteArrayMapper(MimeType mimeType) {
+			return new Mapper<byte[]>() {
+
+				@Override
+				public BiFunction<String, byte[], DataSource> to() { return (name, ba)->new ByteArrayDataSource(ba, Objects.requireNonNull(name, "Name cannot be null."), mimeType); }
+
+				@Override
+				public Function<DataSource, byte[]> from() { return Deconstructor::dsToByteArray; }
+
+				@Override
+				public Class<byte[]> target() { return byte[].class; }
+			};
+		}
+		
+		public static Mapper<Content> CONTENT = new Mapper<Content>() {
+
+			@Override
+			public BiFunction<String, Content, DataSource> to() { return (name, c)->new ByteArrayDataSource(c.bytes, Objects.requireNonNull(name, "Name cannot be null."), c.mimeType); }
+
+			@Override
+			public Function<DataSource, Content> from() { return Deconstructor::dsToContent; }
+
+			@Override
+			public Class<Content> target() { return Content.class; }
+		};
+		
+		public static Mapper<FileContent> FILE_CONTENT = new Mapper<FileContent>() {
+
+			@Override
+			public BiFunction<String, FileContent, DataSource> to() { return (name, fc)->new ByteArrayDataSource(fc.bytes, Objects.requireNonNull(name, "Name cannot be null."), fc.mimeType); }
+
+			@Override
+			public Function<DataSource, FileContent> from() { return Deconstructor::dsToFileContent; }
+
+			@Override
+			public Class<FileContent> target() { return FileContent.class; }
+		};
+		
+		public static Mapper<Boolean> BOOLEAN = new Mapper<Boolean>() {
+
+			@Override
+			public BiFunction<String, Boolean, DataSource> to() { return Builder::<Boolean>objToStringDS; }
+
+			@Override
+			public Function<DataSource, Boolean> from() { return Deconstructor::dsToBoolean; }
+
+			@Override
+			public Class<Boolean> target() { return Boolean.class; }
+		};
+		
+		public static Mapper<Double> DOUBLE = new Mapper<Double>() {
+
+			@Override
+			public BiFunction<String, Double, DataSource> to() { return Builder::<Double>objToStringDS; }
+
+			@Override
+			public Function<DataSource, Double> from() { return Deconstructor::dsToDouble; }
+
+			@Override
+			public Class<Double> target() { return Double.class; }
+		};
+		
+		public static Mapper<Float> FLOAT = new Mapper<Float>() {
+
+			@Override
+			public BiFunction<String, Float, DataSource> to()  { return Builder::<Float>objToStringDS; }
+
+			@Override
+			public Function<DataSource, Float> from() { return Deconstructor::dsToFloat; }
+
+			@Override
+			public Class<Float> target() { return Float.class; }
+		};
+		
+		public static Mapper<Integer> INTEGER = new Mapper<Integer>() {
+
+			@Override
+			public BiFunction<String, Integer, DataSource> to() { return Builder::<Integer>objToStringDS; }
+
+			@Override
+			public Function<DataSource, Integer> from() { return Deconstructor::dsToInteger; }
+
+			@Override
+			public Class<Integer> target() { return Integer.class; }
+		};
+		
+		public static Mapper<Long> LONG = new Mapper<Long>() {
+
+			@Override
+			public BiFunction<String, Long, DataSource> to() { return Builder::<Long>objToStringDS; }
+
+			@Override
+			public Function<DataSource, Long> from() { return Deconstructor::dsToLong; }
+
+			@Override
+			public Class<Long> target() { return Long.class; }
+		};
+		
+		private StandardMappers() { // prevent instantation
+			super();
 		}
 	}
 }

--- a/formsfeeder.core/src/main/java/com/_4point/aem/formsfeeder/core/datasource/DataSourceList.java
+++ b/formsfeeder.core/src/main/java/com/_4point/aem/formsfeeder/core/datasource/DataSourceList.java
@@ -342,10 +342,6 @@ public class DataSourceList implements Iterable<DataSource> {
 			return new StringDataSource(Objects.toString(object), Objects.requireNonNull(name, "Name cannot be null.")); 
 		}
 
-		public static final <T> DataSource objToByteArrayDS(String name, T object) {
-			return new StringDataSource(Objects.toString(object), Objects.requireNonNull(name, "Name cannot be null.")); 
-		}
-
 		public Builder add(DataSource ds) {
 			underConstruction.add(Objects.requireNonNull(ds, "DataSource cannot be null."));
 			return this;

--- a/formsfeeder.core/src/main/java/com/_4point/aem/formsfeeder/core/datasource/DataSourceList.java
+++ b/formsfeeder.core/src/main/java/com/_4point/aem/formsfeeder/core/datasource/DataSourceList.java
@@ -68,7 +68,7 @@ public class DataSourceList implements Iterable<DataSource> {
 	 * @return
 	 */
 	public final List<DataSource> list() {
-		return list;
+		return Collections.unmodifiableList(list);
 	}
 
 	/**

--- a/formsfeeder.core/src/test/java/com/_4point/aem/formsfeeder/core/datasource/DataSourceListBuilderTest.java
+++ b/formsfeeder.core/src/test/java/com/_4point/aem/formsfeeder/core/datasource/DataSourceListBuilderTest.java
@@ -1,21 +1,30 @@
 package com._4point.aem.formsfeeder.core.datasource;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.hamcrest.MatcherAssert.assertThat; 
+import static org.hamcrest.Matchers.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
 import org.opentest4j.MultipleFailuresError;
 
+import com._4point.aem.formsfeeder.core.datasource.DataSourceList.Builder;
+import com._4point.aem.formsfeeder.core.datasource.DataSourceList.Content;
+import com._4point.aem.formsfeeder.core.datasource.DataSourceList.Deconstructor;
+import com._4point.aem.formsfeeder.core.datasource.DataSourceList.Mapper;
 import com._4point.aem.formsfeeder.core.datasource.serialization.XmlDataSourceListDecoderTest;
 import com._4point.aem.formsfeeder.core.support.Jdk8Utils;
 
@@ -144,6 +153,46 @@ class DataSourceListBuilderTest {
 
 	}
 	
+	@Test
+	void testBuildAllWithAddObject() throws Exception{
+		String dslEntryName = "TestDsl";
+		// Construct a DataSourceList with one of each and every type
+		DataSourceList result = DataSourceList.build(DataSourceListBuilderTest::addAllDsTypeObjects);
+		
+		List<DataSource> resultList = result.list();
+		
+		validateResultList(resultList, false);
+	}
+
+	private static DataSourceList.Builder addAllDsTypeObjects(DataSourceList.Builder builder) {
+		return builder.addObject(DUMMY_DS_NAME, dummyDS, DataSource.class)
+					  .addObject(BOOLEAN_DS_NAME, booleanData, Boolean.class)
+					  .addObject(BYTE_ARRAY_DS_NAME, byteArrayData, byte[].class)
+					  .addObject(DOUBLE_DS_NAME, doubleData, Double.class)
+					  .addObject(FLOAT_DS_NAME, floatData, Float.class)
+					  .addObject(INTEGER_DS_NAME, intData, Integer.class)
+					  .addObject(LONG_DS_NAME, longData, Long.class)
+					  .addObject(FILE_DS_NAME, pathData, Path.class)
+					  .addObject(STRING_DS_NAME, stringData, String.class)
+					  .addObject(BYTE_ARRAY_W_CT_DS_NAME, Content.from(byteArrayData, mimeType), Content.class)
+					  .addObject(DSL_DS_NAME, dslData, DataSourceList.class);
+
+	}
+
+	@Test
+	void testBuildWithAddObject_NoMatcher() throws Exception{
+		String objectEntryName = "TestObject";
+		Map<String, String> testObject = System.getenv();
+		// Construct a DataSourceList with one of each and every type
+		UnsupportedOperationException ex = assertThrows(UnsupportedOperationException.class, ()->DataSourceList.builder().addObject(objectEntryName, testObject, Map.class).build());
+		String msg = ex.getMessage();
+		assertNotNull(msg);
+		assertAll(
+				()->assertThat(msg, containsString("No mapping function found for class")),
+				()->assertThat(msg, containsString(Map.class.getName()))
+				);
+	}
+
 	private void validateResultList(List<DataSource> resultList, boolean skipDummyDS) throws MultipleFailuresError {
 		assertAll(
 				()->assertEquals(11, resultList.size()),	// 10 DSes were added.
@@ -293,6 +342,41 @@ class DataSourceListBuilderTest {
 				.build();
 		
 		assertTrue(result.list().isEmpty());
+	}
+
+	@Test
+	void testBuildWithCustomObjectMapperString() {
+		Function<String, String> reverse = s->new StringBuilder(s).reverse().toString();
+		String expectedResult = reverse.apply(stringData);
+		Builder underTest = DataSourceList.builder();
+		Mapper<String> mapper = DataSourceList.StandardMappers.createStringMapper(StandardCharsets.UTF_8);
+		BiFunction<String, String, DataSource> reverseBuilder = (n, s)->mapper.to().apply(n, reverse.apply(s));
+		underTest.register(mapper.target(), reverseBuilder);
+		underTest.addObject(STRING_DS_NAME, stringData, String.class);
+		assertEquals(expectedResult, underTest.build().deconstructor().getStringByName(STRING_DS_NAME).get());
+	}
+
+	@Test
+	void testBuildWithCustomObjectMapperByteArray() {
+		Function<byte[], byte[]> reverse = DataSourceListBuilderTest::reverseBytes;
+		byte[] expectedResult = reverse.apply(byteArrayData);
+		Builder underTest = DataSourceList.builder();
+		Mapper<byte[]> mapper = DataSourceList.StandardMappers.createByteArrayMapper(StandardMimeTypes.TEXT_PLAIN_UTF8_TYPE);
+		BiFunction<String, byte[], DataSource> reverseBuilder = (n,ba)->mapper.to().apply(n, reverse.apply(ba));
+		underTest.register(mapper.target(), reverseBuilder);
+		underTest.addObject(BYTE_ARRAY_DS_NAME, byteArrayData, byte[].class);
+		assertArrayEquals(expectedResult, underTest.build().deconstructor().getByteArrayByName(BYTE_ARRAY_DS_NAME).get());
+	}
+
+	private static byte[] reverseBytes(byte[] validData) {
+		int length = validData.length;
+		int targetLoc = length - 1;
+		byte[] target = new byte[length];
+		for(int i = 0; i < length; i++)
+		{
+			target[targetLoc - i] = validData[i];
+		}
+		return target;
 	}
 
 	private static String readIntoString(InputStream is) throws IOException {

--- a/formsfeeder.core/src/test/java/com/_4point/aem/formsfeeder/core/datasource/DataSourceListDeconstructorTest.java
+++ b/formsfeeder.core/src/test/java/com/_4point/aem/formsfeeder/core/datasource/DataSourceListDeconstructorTest.java
@@ -296,4 +296,11 @@ class DataSourceListDeconstructorTest {
 		assertEquals(stringData, Deconstructor.dsToString(underTest.getDataSourceByName(STRING_DS_NAME).get(), StandardCharsets.UTF_8));
 	}
 	
+	@Test
+	void testGetObject() {
+		Deconstructor underTest = sampleDataSource.deconstructor();
+		underTest.register(String.class, ds->Deconstructor.dsToString(ds));
+		assertEquals(stringData, underTest.getObjectByName(String.class, STRING_DS_NAME).get());
+	}
+	
 }

--- a/formsfeeder.core/src/test/java/com/_4point/aem/formsfeeder/core/datasource/DataSourceListDeconstructorTest.java
+++ b/formsfeeder.core/src/test/java/com/_4point/aem/formsfeeder/core/datasource/DataSourceListDeconstructorTest.java
@@ -347,7 +347,7 @@ class DataSourceListDeconstructorTest {
 	}
 
 	@Test
-	void testGetObject() {
+	void testGetObjectByName() {
 		Deconstructor underTest = sampleDataSource.deconstructor();
 		assertAll(
 				()->assertEquals(dummyDS, underTest.getObjectByName(DataSource.class, DUMMY_DS_NAME).get()),
@@ -364,10 +364,116 @@ class DataSourceListDeconstructorTest {
 				);
 		
 		// Since the File does not exist, we expect an error here.
-		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, ()->underTest.getStringByName(FILE_DS_NAME).get());
+		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, ()->underTest.getStringByName(FILE_DS_NAME));
 		String msg = ex.getMessage();
 		assertNotNull(msg);
 		assertTrue(msg.contains(pathData.toString()));
+	}
+
+	@Test
+	void testGetObjectByPredicate() {
+		Deconstructor underTest = sampleDataSource.deconstructor();
+
+		assertAll(
+				()->assertEquals(dummyDS, underTest.getObject(DataSource.class, DataSourceList.byName(DUMMY_DS_NAME)).get()),
+				()->assertEquals(booleanData, underTest.getObject(Boolean.class, DataSourceList.byName(BOOLEAN_DS_NAME)).get()),
+				()->assertArrayEquals(byteArrayData, underTest.getObject(byte[].class, DataSourceList.byName(BYTE_ARRAY_DS_NAME)).get()),
+				()->assertEquals(doubleData, underTest.getObject(Double.class, DataSourceList.byName(DOUBLE_DS_NAME)).get()),
+				()->assertEquals(floatData, underTest.getObject(Float.class, DataSourceList.byName(FLOAT_DS_NAME)).get()),
+				()->assertEquals(intData, underTest.getObject(Integer.class, DataSourceList.byName(INTEGER_DS_NAME)).get()),
+				()->assertEquals(longData, underTest.getObject(Long.class, DataSourceList.byName(LONG_DS_NAME)).get()),
+				()->assertEquals(stringData, underTest.getObject(String.class, DataSourceList.byName(STRING_DS_NAME)).get()),
+				()->XmlDataSourceListDecoderTest.dslEquals(dslData, underTest.getObject(DataSourceList.class, DataSourceList.byName(DSL_DS_NAME)).get(), true),
+				()->assertEquals(contentData, underTest.getObject(Content.class, DataSourceList.byName(CONTENT_DS_NAME)).get()),
+				()->assertEquals(fileContentData, underTest.getObject(FileContent.class, DataSourceList.byName(FILE_CONTENT_DS_NAME)).get())
+				);
+		
+		// Since the File does not exist, we expect an error here.
+		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, ()->underTest.getObject(String.class, DataSourceList.byName(FILE_DS_NAME)).get());
+		String msg = ex.getMessage();
+		assertNotNull(msg);
+		assertTrue(msg.contains(pathData.toString()));
+	}
+	
+	@Test
+	void testGetMultipleObjectsByName() {
+		Deconstructor underTest = sampleDataSource.deconstructor();
+		assertAll(
+				()->assertEquals(dummyDS, underTest.getObjectsByName(DataSource.class, DUMMY_DS_NAME).get(0)),
+				()->assertEquals(2, underTest.getObjectsByName(DataSource.class, DUMMY_DS_NAME).size()),
+				()->assertEquals(booleanData, underTest.getObjectsByName(Boolean.class, BOOLEAN_DS_NAME).get(0)),
+				()->assertEquals(3, underTest.getObjectsByName(Boolean.class, BOOLEAN_DS_NAME).size()),
+				()->assertArrayEquals(byteArrayData, underTest.getObjectsByName(byte[].class, BYTE_ARRAY_DS_NAME).get(0)),
+				()->assertEquals(1, underTest.getObjectsByName(byte[].class, BYTE_ARRAY_DS_NAME).size()),
+				()->assertEquals(doubleData, underTest.getObjectsByName(Double.class, DOUBLE_DS_NAME).get(0)),
+				()->assertEquals(2, underTest.getObjectsByName(Double.class, DOUBLE_DS_NAME).size()),
+				()->assertEquals(floatData, underTest.getObjectsByName(Float.class, FLOAT_DS_NAME).get(0)),
+				()->assertEquals(3, underTest.getObjectsByName(Float.class, FLOAT_DS_NAME).size()),
+				()->assertEquals(intData, underTest.getObjectsByName(Integer.class, INTEGER_DS_NAME).get(0)),
+				()->assertEquals(1, underTest.getObjectsByName(Integer.class, INTEGER_DS_NAME).size()),
+				()->assertEquals(longData, underTest.getObjectsByName(Long.class, LONG_DS_NAME).get(0)),
+				()->assertEquals(2, underTest.getObjectsByName(Long.class, LONG_DS_NAME).size()),
+				()->assertEquals(stringData, underTest.getObjectsByName(String.class, STRING_DS_NAME).get(0)),
+				()->assertEquals(1, underTest.getObjectsByName(String.class, STRING_DS_NAME).size()),
+				()->XmlDataSourceListDecoderTest.dslEquals(dslData, underTest.getObjectsByName(DataSourceList.class, DSL_DS_NAME).get(0), true),
+				()->assertEquals(2, underTest.getObjectsByName(DataSourceList.class, DSL_DS_NAME).size()),
+				()->assertEquals(contentData, underTest.getObjectsByName(Content.class, CONTENT_DS_NAME).get(0)),
+				()->assertEquals(3, underTest.getObjectsByName(Content.class, CONTENT_DS_NAME).size()),
+				()->assertEquals(fileContentData, underTest.getObjectsByName(FileContent.class, FILE_CONTENT_DS_NAME).get(0)),
+				()->assertEquals(1, underTest.getObjectsByName(FileContent.class, FILE_CONTENT_DS_NAME).size())
+				);
+		
+		// Since the File does not exist, we expect an error here.
+		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, ()->underTest.getObjectsByName(String.class, FILE_DS_NAME).size());
+		String msg = ex.getMessage();
+		assertNotNull(msg);
+		assertTrue(msg.contains(pathData.toString()));
+	}
+
+	@Test
+	void testGetMultipleObjectsByPredicateByName() {
+		Deconstructor underTest = sampleDataSource.deconstructor();
+		assertAll(
+				()->assertEquals(dummyDS, underTest.getObjects(DataSource.class, DataSourceList.byName(DUMMY_DS_NAME)).get(0)),
+				()->assertEquals(2, underTest.getObjects(DataSource.class, DataSourceList.byName(DUMMY_DS_NAME)).size()),
+				()->assertEquals(booleanData, underTest.getObjects(Boolean.class, DataSourceList.byName(BOOLEAN_DS_NAME)).get(0)),
+				()->assertEquals(3, underTest.getObjects(Boolean.class, DataSourceList.byName(BOOLEAN_DS_NAME)).size()),
+				()->assertArrayEquals(byteArrayData, underTest.getObjects(byte[].class, DataSourceList.byName(BYTE_ARRAY_DS_NAME)).get(0)),
+				()->assertEquals(1, underTest.getObjects(byte[].class, DataSourceList.byName(BYTE_ARRAY_DS_NAME)).size()),
+				()->assertEquals(doubleData, underTest.getObjects(Double.class, DataSourceList.byName(DOUBLE_DS_NAME)).get(0)),
+				()->assertEquals(2, underTest.getObjects(Double.class, DataSourceList.byName(DOUBLE_DS_NAME)).size()),
+				()->assertEquals(floatData, underTest.getObjects(Float.class, DataSourceList.byName(FLOAT_DS_NAME)).get(0)),
+				()->assertEquals(3, underTest.getObjects(Float.class, DataSourceList.byName(FLOAT_DS_NAME)).size()),
+				()->assertEquals(intData, underTest.getObjects(Integer.class, DataSourceList.byName(INTEGER_DS_NAME)).get(0)),
+				()->assertEquals(1, underTest.getObjects(Integer.class, DataSourceList.byName(INTEGER_DS_NAME)).size()),
+				()->assertEquals(longData, underTest.getObjects(Long.class, DataSourceList.byName(LONG_DS_NAME)).get(0)),
+				()->assertEquals(2, underTest.getObjects(Long.class, DataSourceList.byName(LONG_DS_NAME)).size()),
+				()->assertEquals(stringData, underTest.getObjects(String.class, DataSourceList.byName(STRING_DS_NAME)).get(0)),
+				()->assertEquals(1, underTest.getObjects(String.class, DataSourceList.byName(STRING_DS_NAME)).size()),
+				()->XmlDataSourceListDecoderTest.dslEquals(dslData, underTest.getObjects(DataSourceList.class, DataSourceList.byName(DSL_DS_NAME)).get(0), true),
+				()->assertEquals(2, underTest.getObjects(DataSourceList.class, DataSourceList.byName(DSL_DS_NAME)).size()),
+				()->assertEquals(contentData, underTest.getObjects(Content.class, DataSourceList.byName(CONTENT_DS_NAME)).get(0)),
+				()->assertEquals(3, underTest.getObjects(Content.class, DataSourceList.byName(CONTENT_DS_NAME)).size()),
+				()->assertEquals(fileContentData, underTest.getObjects(FileContent.class, DataSourceList.byName(FILE_CONTENT_DS_NAME)).get(0)),
+				()->assertEquals(1, underTest.getObjects(FileContent.class, DataSourceList.byName(FILE_CONTENT_DS_NAME)).size())
+				);
+		
+		// Since the File does not exist, we expect an error here.
+		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, ()->underTest.getObjects(String.class, DataSourceList.byName(FILE_DS_NAME)).size());
+		String msg = ex.getMessage();
+		assertNotNull(msg);
+		assertTrue(msg.contains(pathData.toString()));
+	}
+
+	@Test
+	void testGetMultipleObjectsWithNonNamePredicate() {
+		Deconstructor underTest = sampleDataSource.deconstructor();
+		// First DS with octet-stream type is the dummy DS
+		assertEquals(dummyDS, underTest.getObjects(DataSource.class, ds->ds.contentType().equals(StandardMimeTypes.APPLICATION_OCTET_STREAM_TYPE)).get(0));
+		// Two dummyDS entries plus the one byte array should all have an mime-type of application/octet-stream.
+		assertEquals(3, underTest.getDataSources(ds->ds.contentType().equals(StandardMimeTypes.APPLICATION_OCTET_STREAM_TYPE)).size());
+		// Test where nothing matches.
+		assertTrue(underTest.getDataSources(ds->false).isEmpty());
 	}
 
 	@Test


### PR DESCRIPTION
Added the concept of custom "Mappers" that will map an object to a DataSource and a DataSource to an object.  A list of Standard Mappers is provided for mapping java primitives.